### PR TITLE
Making sure timezone JST is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ before_install:
 script:
   - bash tests/fetch_test.sh
   - docker build --tag=kuropen/elecwarn-don:testing .
+  - bash tests/docker_tz_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
   - sudo apt-get install -y build-essential gfortran libatlas-base-dev liblapack-dev jq
 script:
   - bash tests/fetch_test.sh
-  - docker build --tag=kuropen/elecwarn-don .
+  - docker build --tag=kuropen/elecwarn-don:testing .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
     liblapack-dev \
     busybox-static
 
+RUN echo "${TZ}" > /etc/timezone && dpkg-reconfigure -f noninteractive tzdata
+
 RUN mkdir /elecwarn
 ADD . /elecwarn
 

--- a/tests/docker_tz_test.sh
+++ b/tests/docker_tz_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Test script for Electricity Warning Crawler, Python Edition.
+# Copyright (C) 2018 Hirochika Yuda, a.k.a. Kuropen.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+cd $(dirname $0)
+cd ..
+
+TESTFILE=$(mktemp)
+
+docker run --rm kuropen/elecwarn-don:testing LANG=C date | tee $TESTFILE
+grep JST $TESTFILE > /dev/null
+
+# Fails if JST is not included (timezone is wrong)
+exit $?

--- a/tests/docker_tz_test.sh
+++ b/tests/docker_tz_test.sh
@@ -21,7 +21,7 @@ cd ..
 
 TESTFILE=$(mktemp)
 
-docker run --rm kuropen/elecwarn-don:testing LANG=C date | tee $TESTFILE
+docker run --rm kuropen/elecwarn-don:testing date | tee $TESTFILE
 grep JST $TESTFILE > /dev/null
 
 # Fails if JST is not included (timezone is wrong)


### PR DESCRIPTION
This is to make sure timezone other than JST is not used anywhere, because accessing CSVs before 1:00 AM JST raises the rate of failure.
We are migrating the bot to Arukas (#6), where we cannot control the server itself, so the timezone should be fixed within the container image.
